### PR TITLE
Fix #16: abrupt client disconnect no longer leaves handler thread spinning

### DIFF
--- a/telnetsrv/telnetsrvlib.py
+++ b/telnetsrv/telnetsrvlib.py
@@ -1056,23 +1056,26 @@ class TelnetHandlerBase(socketserver.BaseRequestHandler):
             self.writeline(self.WELCOME)
 
         self.session_start()
-        while self.RUNSHELL:
-            raw_input = self.readline(prompt=self.PROMPT).strip()
-            self.input = self.input_reader(self, raw_input)
-            self.raw_input = self.input.raw
-            if self.input.cmd:
-                cmd = self.input.cmd.upper()
-                params = self.input.params
-                if cmd in self.COMMANDS:
-                    try:
-                        self.COMMANDS[cmd](params)
-                    except Exception:
-                        log.exception("Error calling %s." % cmd)
-                        (t, p, tb) = sys.exc_info()
-                        if self.handleException(t, p, tb):
-                            break
-                else:
-                    self.writeerror("Unknown command '%s'" % cmd)
+        try:
+            while self.RUNSHELL:
+                raw_input = self.readline(prompt=self.PROMPT).strip()
+                self.input = self.input_reader(self, raw_input)
+                self.raw_input = self.input.raw
+                if self.input.cmd:
+                    cmd = self.input.cmd.upper()
+                    params = self.input.params
+                    if cmd in self.COMMANDS:
+                        try:
+                            self.COMMANDS[cmd](params)
+                        except Exception:
+                            log.exception("Error calling %s." % cmd)
+                            (t, p, tb) = sys.exc_info()
+                            if self.handleException(t, p, tb):
+                                break
+                    else:
+                        self.writeerror("Unknown command '%s'" % cmd)
+        except EOFError:
+            log.debug("Connection closed by remote host")
         log.debug("Exiting handler")
 
 

--- a/telnetsrv/threaded.py
+++ b/telnetsrv/threaded.py
@@ -47,6 +47,8 @@ class TelnetHandler(TelnetHandlerBase):
             if not len(self.cookedq):
                 return ""
         while not len(self.cookedq):
+            if self.eof:
+                raise EOFError
             time.sleep(0.05)
         self.IQUEUELOCK.acquire()
         ret = self.cookedq[0]

--- a/tests/test_threaded.py
+++ b/tests/test_threaded.py
@@ -5,6 +5,7 @@ import socketserver
 import threading
 import time
 import pytest
+from unittest import mock
 
 from telnetsrv.threaded import TelnetHandler, command
 
@@ -235,3 +236,43 @@ class TestThreadedIntegration:
         data = c.read_until(b"$ ")
         assert b"EXIT" in data or b"ECHO" in data
         c.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #16: abrupt disconnect must not leave the handler thread spinning
+# ---------------------------------------------------------------------------
+
+
+class _DisconnectServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+class TestAbruptDisconnect:
+    """When the client closes the TCP connection without sending EXIT, the
+    server-side handler thread must terminate on its own rather than spin
+    forever in getc() waiting for input that will never arrive."""
+
+    def test_abrupt_disconnect_terminates_session(self):
+        handler_finished = threading.Event()
+
+        class TrackingHandler(EchoHandler):
+            def finish(self):
+                super().finish()
+                handler_finished.set()
+
+        srv = _DisconnectServer(("127.0.0.1", 0), TrackingHandler)
+        t = threading.Thread(target=srv.serve_forever)
+        t.daemon = True
+        t.start()
+
+        try:
+            c = _TelnetClient(*srv.server_address)
+            c.read_until(b"$ ")  # wait for the shell prompt so handle() is in getc()
+            c.close()  # abrupt disconnect — no EXIT command
+            assert handler_finished.wait(timeout=3), (
+                "Handler thread did not terminate after abrupt disconnect "
+                "(getc() is probably spinning forever)"
+            )
+        finally:
+            srv.shutdown()


### PR DESCRIPTION
## Summary

- When a telnet client drops the TCP connection mid-session (instead of sending `EXIT`), the `inputcooker` thread exited cleanly but the main handler thread was left spinning forever in `getc()`, consuming CPU and never freeing the session.
- `getc()` in `threaded.py` now checks `self.eof` on each busy-wait iteration and raises `EOFError` when the connection is gone.
- `handle()` in `telnetsrvlib.py` wraps the command loop in `try/except EOFError` so the session terminates cleanly rather than propagating an unexpected exception.

## Test plan

- [ ] New integration test `TestAbruptDisconnect.test_abrupt_disconnect_terminates_session` connects a real client to a real threaded server, waits for the shell prompt (so `handle()` is blocked in `getc()`), then closes the socket abruptly and asserts that `finish()` is called within 3 seconds — this test **failed** before the fix and **passes** after.
- [ ] Full test suite: `uv run pytest` — 185/185 pass.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)