### PR TITLE
Fix NAWS (issues #7 and #11): window size negotiation

### DIFF
--- a/telnetsrv/telnetsrvlib.py
+++ b/telnetsrv/telnetsrvlib.py
@@ -29,6 +29,7 @@ import traceback
 import curses.ascii
 import curses
 import logging
+import struct
 from collections.abc import Callable
 from typing import Any
 
@@ -393,7 +394,7 @@ class TelnetHandlerBase(socketserver.BaseRequestHandler):
     WILLACK: dict[str, str] = {
         ECHO: DONT,
         SGA: DO,
-        NAWS: DONT,
+        NAWS: DO,
         TTYPE: DO,
         LINEMODE: DONT,
         NEW_ENVIRON: DO,
@@ -469,6 +470,8 @@ class TelnetHandlerBase(socketserver.BaseRequestHandler):
         self.sb = 0  # Flag for SB and SE sequence.
         self.history: list[str] = []  # Command history
         self.RUNSHELL = True
+        self.WIDTH = 80
+        self.HEIGHT = 24
         # A little magic - Everything called cmdXXX is a command
         # Also, check for decorated functions
         for k in dir(self):
@@ -523,6 +526,15 @@ class TelnetHandlerBase(socketserver.BaseRequestHandler):
         self.CODES["INS"] = (curses.tigetstr("ich1") or b"").decode("latin-1")
         self.CODES["CSRLEFT"] = (curses.tigetstr("cub1") or b"").decode("latin-1")
         self.CODES["CSRRIGHT"] = (curses.tigetstr("cuf1") or b"").decode("latin-1")
+
+    def setnaws(self, data: str) -> None:
+        "Update terminal width and height from a NAWS subnegotiation payload"
+        if len(data) < 4:
+            log.debug("NAWS data too short: %r", data)
+            return
+        raw = data[:4].encode("latin-1")
+        self.WIDTH, self.HEIGHT = struct.unpack(">HH", raw)
+        log.debug("NAWS: width=%s height=%s", self.WIDTH, self.HEIGHT)
 
     def setup(self) -> None:
         "Connect incoming connection to a telnet session"

--- a/tests/test_naws.py
+++ b/tests/test_naws.py
@@ -1,0 +1,64 @@
+"""Tests for NAWS (Negotiate About Window Size, RFC 1073)."""
+
+import struct
+
+from telnetsrv.telnetsrvlib import NAWS, DO, SE, NOOPT
+
+
+def naws_payload(width: int, height: int) -> str:
+    """Build the 4-byte NAWS subnegotiation body as a latin-1 string."""
+    return struct.pack(">HH", width, height).decode("latin-1")
+
+
+class TestSetnaws:
+    def test_sets_width_and_height(self, handler):
+        handler.setnaws(naws_payload(132, 50))
+        assert handler.WIDTH == 132
+        assert handler.HEIGHT == 50
+
+    def test_updates_on_second_call(self, handler):
+        handler.setnaws(naws_payload(80, 24))
+        handler.setnaws(naws_payload(200, 60))
+        assert handler.WIDTH == 200
+        assert handler.HEIGHT == 60
+
+    def test_short_data_ignored(self, handler):
+        original_w, original_h = handler.WIDTH, handler.HEIGHT
+        handler.setnaws("xx")  # only 2 bytes — too short
+        assert handler.WIDTH == original_w
+        assert handler.HEIGHT == original_h
+
+    def test_large_dimensions(self, handler):
+        handler.setnaws(naws_payload(65535, 65535))
+        assert handler.WIDTH == 65535
+        assert handler.HEIGHT == 65535
+
+
+class TestNawsDefaults:
+    def test_width_has_default(self, handler):
+        assert isinstance(handler.WIDTH, int)
+        assert handler.WIDTH > 0
+
+    def test_height_has_default(self, handler):
+        assert isinstance(handler.HEIGHT, int)
+        assert handler.HEIGHT > 0
+
+
+class TestNawsNegotiation:
+    def test_willack_requests_naws_from_client(self, handler):
+        assert handler.WILLACK[NAWS] == DO
+
+    def test_options_handler_se_naws_updates_dimensions(self, handler):
+        handler.sbdataq = NAWS + naws_payload(120, 40)
+        handler.options_handler(handler.sock, SE, NOOPT)
+        assert handler.WIDTH == 120
+        assert handler.HEIGHT == 40
+
+    def test_options_handler_se_naws_resize_during_session(self, handler):
+        handler.sbdataq = NAWS + naws_payload(80, 24)
+        handler.options_handler(handler.sock, SE, NOOPT)
+        # Simulate client resizing the window
+        handler.sbdataq = NAWS + naws_payload(160, 48)
+        handler.options_handler(handler.sock, SE, NOOPT)
+        assert handler.WIDTH == 160
+        assert handler.HEIGHT == 48


### PR DESCRIPTION
## Summary

- Restores the `setnaws()` method that was dropped during the Python 3 modernization (PR #26), fixing a latent `AttributeError` if any client sent NAWS data
- Changes `WILLACK[NAWS]` from `DONT` to `DO` so the server actually requests window size from clients (fixes issue #7)
- Initializes `self.WIDTH = 80` and `self.HEIGHT = 24` as safe defaults
- Adds `import struct` (also lost in the modernization)
- Mid-session resize (issue #11) works automatically — `options_handler` already dispatches every NAWS subnegotiation to `setnaws`, so clients that re-send NAWS on resize are handled without any extra logic

## Test plan

- [ ] Run `pytest tests/test_naws.py -v` — 9 new tests covering parsing, defaults, negotiation flag, and mid-session resize
- [ ] Run full suite `pytest` — all 194 tests pass
- [ ] Connect a real telnet client (e.g. `telnet` or `minicom`) and verify `self.WIDTH`/`self.HEIGHT` reflect the actual terminal size

Closes #7
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)