### PR TITLE
Warn when SSH server allows 'none' authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -515,6 +515,17 @@ can be defined, and if all three are defined, all three will be tried before den
 An SSH client will always provide a username.  If no ``authCallbackXX`` is defined, the SSH authentication will be
 set to "none" and any username will be able to log in.
 
+When "none" authentication is active, a warning is logged each time a connection is established as a reminder
+that the server is unauthenticated.  If this is intentional (e.g. a local development server), suppress the
+warning by setting ``warn_of_insecure_auth = False`` in your ``SSHHandler`` subclass:
+
+.. code:: python
+
+   class MySSHHandler(SSHHandler):
+       host_key = getRsaKeyFile('server_fingerprint.key')
+       telnet_handler = MyTelnetHandler
+       warn_of_insecure_auth = False  # suppress warning: no auth is intentional
+
 ``authCallbackUsername(self, username)``
   Reference to username-only authentication function.  Define this function to permit specific usernames
   to log in without any futher authentication.  Raise any exception to deny this authentication attempt.

--- a/telnetsrv/paramiko_ssh.py
+++ b/telnetsrv/paramiko_ssh.py
@@ -52,6 +52,7 @@ class SSHHandler(ServerInterface, BaseRequestHandler):
     pty_handler = None
     host_key = None
     username = None
+    warn_of_insecure_auth = True
 
     def __init__(self, request, client_address, server):
         self.request = request
@@ -99,6 +100,12 @@ class SSHHandler(ServerInterface, BaseRequestHandler):
                     "Host key not set!  SSHHandler instance must define host_key."
                     '  Try host_key = paramiko_ssh.getRsaKeyFile("server_rsa.key").'
                 )
+
+        if self.warn_of_insecure_auth and "none" in self.get_allowed_auths("").split(","):
+            log.warning(
+                "SSH server allows 'none' authentication — clients can connect without credentials. "
+                "Set authCallback, authCallbackKey, or authCallbackUsername to require authentication."
+            )
 
         try:
             # Tell transport to use this object as a server


### PR DESCRIPTION
## Summary

- Adds `warn_of_insecure_auth = True` class attribute to `SSHHandler`; when `True` and no auth callbacks are configured (causing the server to advertise and accept SSH `none` auth), a `WARNING` is logged on each connection attempt
- Implementers can set `warn_of_insecure_auth = False` to suppress the warning when unauthenticated access is intentional
- Documents the property and suppression pattern in `README.rst` under the SSH Authentication section

## Test plan

- [ ] Start an SSH server with no `authCallbackXX` defined and confirm a `WARNING` is logged on connection
- [ ] Set `warn_of_insecure_auth = False` and confirm no warning is logged
- [ ] Set any `authCallbackXX` and confirm no warning is logged (since `"none"` is no longer in the allowed methods)

🤖 Generated with [Claude Code](https://claude.com/claude-code)