### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: pip install ".[ssh]" pytest pytest-cov
+
+      - name: Run tests
+        run: pytest

--- a/telnetsrv/telnetsrvlib.py
+++ b/telnetsrv/telnetsrvlib.py
@@ -22,6 +22,8 @@ Various settings can affect the operation of the server:
                    Function.aliases may be a list of alternative spellings
 """
 
+from __future__ import annotations
+
 import socketserver
 import socket
 import sys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from unittest import mock
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs `pytest` on every pull request and push to `master`
- Matrix runs across Python 3.9, 3.10, 3.11, and 3.12 (matching `requires-python = ">=3.9"`)
- Installs with the `ssh` extra so paramiko is available for the full test suite

## Enabling branch protection

To block merging PRs with failing tests, after this workflow runs once:

1. Go to **Settings → Branches → Add branch protection rule**
2. Branch name pattern: `master`
3. Enable **"Require status checks to pass before merging"**
4. Add the `test` check (appears after first run)

## Test plan

- [ ] Confirm all matrix jobs pass on this PR
- [ ] Set up branch protection rule to require the `test` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)