### PR TITLE
Install dev extras in CI so pytest-asyncio is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install ".[ssh]" pytest pytest-cov
+        run: pip install ".[ssh,dev]"
 
       - name: Run tests
         run: pytest


### PR DESCRIPTION
## Summary

- The `[dev]` extras include `pytest-asyncio`, which is required for the async handler tests added in #38.
- The old CI install command (`pip install ".[ssh]" pytest pytest-cov`) omitted the dev extras, so `pytest-asyncio` was never installed.
- Without it, every `async def` test fails with *"async def functions are not natively supported"*.
- This fixes the install to `pip install ".[ssh,dev]"`, which pulls in all test dependencies declared in `pyproject.toml`.

## Why a separate PR

GitHub Actions uses the workflow file from the **base branch** for `pull_request` events, so the same fix in PR #38 has no effect until it lands on `master`. Merging this first unblocks CI on #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)