### PR TITLE
Add asyncio example server and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # telnetsrvlib
 
-Telnet server using gevent or threading.
+Telnet server using gevent, threading, or asyncio.
 
 Copied from http://pytelnetsrvlib.sourceforge.net/
-and modified to support gevent and eventlet, better input handling, clean asynchronous messages and much more.
+and modified to support gevent, eventlet, asyncio, better input handling, clean asynchronous messages and much more.
 Licensed under the LGPL, as per the SourceForge notes.
 
 **Requires Python 3.10 or later.**
@@ -17,8 +17,7 @@ an SSH handler.
 You use the library to create your own handler, then pass that handler to a StreamServer
 or TCPServer to perform the actual connection tasks.
 
-This library includes two flavors of the server handler, one uses separate threads,
-the other uses greenlets (green pseudo-threads) via gevent or eventlet.
+This library includes three flavors of the server handler: threaded, green, and asyncio.
 
 The threaded version uses a separate thread to process the input buffer and
 semaphores reading and writing. The provided test server only handles a single
@@ -27,6 +26,10 @@ connection at a time.
 The green version moves the input buffer processing into a greenlet to allow
 cooperative multi-processing. This results in significantly less memory usage
 and nearly no idle processing. The provided test server handles a large number of connections.
+
+The asyncio version integrates with Python's built-in asyncio event loop, requiring
+no extra dependencies. It supports async command handlers and handles multiple
+connections efficiently.
 
 
 ## Install
@@ -388,8 +391,9 @@ class MyHandler(TelnetHandler):
 
 Now you have a shiny new handler class, but it doesn't serve itself - it must be called
 from an appropriate server. The server will create an instance of the TelnetHandler class
-for each new connection. The handler class will work with either a gevent StreamServer instance
-(for the green version) or with a `socketserver.TCPServer` instance (for the threaded version).
+for each new connection. The handler class will work with a gevent StreamServer instance (for the green version),
+a `socketserver.TCPServer` instance (for the threaded version), or `asyncio.start_server`
+(for the asyncio version).
 
 ### Threaded
 
@@ -462,8 +466,8 @@ stream; the data is flushed to the network automatically between command invocat
 ## Short Example
 
 ```python
-import gevent, gevent.server
-from telnetsrv.green import TelnetHandler, cmd, Commands
+import asyncio
+from telnetsrv.aio import TelnetHandler, cmd, Commands
 
 class MyCommands(Commands):
     @cmd(['echo', 'copy', 'repeat'])
@@ -475,7 +479,7 @@ class MyCommands(Commands):
         self.handler.writeresponse(' '.join(params))
 
     @cmd('timer')
-    def timer(self, params):
+    async def timer(self, params):
         '''<time> <message>
         In <time> seconds, display <message>.
         Send a message after a delay.
@@ -491,7 +495,8 @@ class MyCommands(Commands):
             self.handler.writeerror("Need both a time and a message")
             return
         self.handler.writeresponse("Waiting %d seconds..." % delay)
-        gevent.spawn_later(delay, self.handler.writemessage, message)
+        await asyncio.sleep(delay)
+        self.handler.writemessage(message)
 
 
 class MyTelnetHandler(TelnetHandler):
@@ -499,8 +504,14 @@ class MyTelnetHandler(TelnetHandler):
     commands_class = MyCommands
 
 
-server = gevent.server.StreamServer(("", 8023), MyTelnetHandler.streamserver_handle)
-server.serve_forever()
+async def main():
+    server = await asyncio.start_server(
+        MyTelnetHandler.asyncio_handle, host="", port=8023
+    )
+    async with server:
+        await server.serve_forever()
+
+asyncio.run(main())
 ```
 
 
@@ -698,3 +709,20 @@ server.serve_forever()
 ## Longer Example
 
 See https://github.com/ianepperson/telnetsrvlib/blob/master/example.py
+
+Demonstrates the threaded and green flavors of the library. Accepts `--green`
+(gevent), `--eventlet`, or defaults to threaded. Also supports `--ssh` via
+`SSHHandler` with Paramiko. The `timer` command uses `gevent.spawn_later`,
+`eventlet.spawn_after`, or `threading.Timer` depending on the selected backend,
+and `passwd` uses the synchronous `handler.readline()` for secure input.
+
+## Asyncio Example
+
+See https://github.com/ianepperson/telnetsrvlib/blob/master/example-asyncio.py
+
+Demonstrates the asyncio flavor of the library. Supports both plain telnet
+(served via `asyncio.start_server`) and SSH (served via `socketserver.TCPServer`
+with `AsyncSSHHandler`, which runs each session's async handler in its own
+`asyncio.run()` call). The `timer` command uses `asyncio.create_task` for
+non-blocking delayed messages, and `passwd` uses `await handler.readline()`
+for secure input.

--- a/example-asyncio-test.py
+++ b/example-asyncio-test.py
@@ -1,0 +1,528 @@
+"""Tests for example-asyncio.py — the asyncio demonstration server."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+# example-asyncio.py calls parse_args() at import time; supply required port arg.
+with mock.patch("sys.argv", ["example-asyncio", "8023"]):
+    import importlib  # noqa: E402
+    import sys  # noqa: E402
+
+    spec = importlib.util.spec_from_file_location(
+        "example_asyncio", "example-asyncio.py"
+    )
+    example_asyncio = importlib.util.module_from_spec(spec)
+    sys.modules["example_asyncio"] = example_asyncio
+    spec.loader.exec_module(example_asyncio)
+
+MyServer = example_asyncio.MyServer
+MyCommands = example_asyncio.MyCommands
+ExampleTelnetHandler = example_asyncio.ExampleTelnetHandler
+
+from telnetsrv.aio import TelnetHandler  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirror test_aio.py infrastructure)
+# ---------------------------------------------------------------------------
+
+
+class MockWriter:
+    def __init__(self):
+        self.written = b""
+        self._closed = False
+
+    def write(self, data: bytes) -> None:
+        self.written += data
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self._closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+    def get_extra_info(self, name, default=None):
+        return default
+
+    @property
+    def sent(self) -> str:
+        return self.written.decode("latin-1")
+
+
+class MockReader:
+    def __init__(self, data: bytes = b""):
+        self._data = data
+        self._pos = 0
+
+    async def read(self, n: int = -1) -> bytes:
+        chunk = self._data[self._pos : self._pos + (n if n >= 0 else len(self._data))]
+        self._pos += len(chunk)
+        return chunk
+
+
+def make_handler(handler_class=None, reader_data: bytes = b"") -> TelnetHandler:
+    cls = handler_class or ExampleTelnetHandler
+    h = cls(MockReader(reader_data), MockWriter())
+    h.setterm(h.TERM)
+    return h
+
+
+def feed(handler, chars) -> None:
+    for c in chars:
+        handler.cookedq.put_nowait(c)
+
+
+def recv(handler) -> str:
+    return handler.writer.sent
+
+
+# ---------------------------------------------------------------------------
+# MyServer
+# ---------------------------------------------------------------------------
+
+
+class TestMyServer:
+    def test_initial_connection_count_is_zero(self):
+        assert MyServer().connection_count == 0
+
+    def test_initial_user_connect_is_empty(self):
+        assert MyServer().user_connect == {}
+
+    def test_first_connection_returns_one_one(self):
+        s = MyServer()
+        global_count, user_count = s.new_connection("alice")
+        assert global_count == 1
+        assert user_count == 1
+
+    def test_global_count_increments_across_users(self):
+        s = MyServer()
+        s.new_connection("alice")
+        global_count, _ = s.new_connection("bob")
+        assert global_count == 2
+
+    def test_per_user_count_increments_on_reconnect(self):
+        s = MyServer()
+        s.new_connection("alice")
+        _, user_count = s.new_connection("alice")
+        assert user_count == 2
+
+    def test_different_users_have_independent_counts(self):
+        s = MyServer()
+        _, alice = s.new_connection("alice")
+        _, bob = s.new_connection("bob")
+        assert alice == 1
+        assert bob == 1
+
+    def test_global_count_tracks_all_connections(self):
+        s = MyServer()
+        for _ in range(5):
+            s.new_connection("alice")
+        assert s.connection_count == 5
+
+
+# ---------------------------------------------------------------------------
+# MockHandler for MyCommands unit tests
+# ---------------------------------------------------------------------------
+
+
+class MockHandler:
+    def __init__(self):
+        self.responses = []
+        self.errors = []
+        self.messages = []
+        self.username = "testuser"
+        self.TERM = "xterm"
+        self.WIDTH = 80
+        self.HEIGHT = 24
+        self.history = ["cmd1", "cmd2"]
+        self.ESCSEQ = {}
+        self.KEYS = {}
+        self.myserver = MyServer()
+        self.timer_events = []
+        self._readline_responses = []
+
+    def writeresponse(self, text):
+        self.responses.append(text)
+
+    def writeerror(self, text):
+        self.errors.append(text)
+
+    def writemessage(self, text):
+        self.messages.append(text)
+
+    async def readline(self, prompt="", echo=True, use_history=True):
+        return self._readline_responses.pop(0) if self._readline_responses else ""
+
+
+# ---------------------------------------------------------------------------
+# MyCommands
+# ---------------------------------------------------------------------------
+
+
+class TestMyCommands:
+    def setup_method(self):
+        self.handler = MockHandler()
+        self.cmds = MyCommands(self.handler)
+
+    def test_params_echoes_repr(self):
+        self.cmds.params(["hello", "world"])
+        assert any("['hello', 'world']" in r for r in self.handler.responses)
+
+    def test_debug_writes_one_line_per_escape_sequence(self):
+        self.handler.ESCSEQ = {"\x1b[A": 1}
+        self.handler.KEYS = {1: "UP"}
+        self.cmds.debug([])
+        assert len(self.handler.responses) == 1
+
+    def test_debug_includes_key_name(self):
+        self.handler.ESCSEQ = {"\x1b[A": 1}
+        self.handler.KEYS = {1: "UP"}
+        self.cmds.debug([])
+        assert "UP" in self.handler.responses[0]
+
+    def test_info_contains_username(self):
+        self.cmds.info([])
+        assert "testuser" in " ".join(self.handler.responses)
+
+    def test_info_contains_term(self):
+        self.cmds.info([])
+        assert "xterm" in " ".join(self.handler.responses)
+
+    def test_info_contains_dimensions(self):
+        self.cmds.info([])
+        combined = " ".join(self.handler.responses)
+        assert "80" in combined and "24" in combined
+
+    def test_info_lists_history(self):
+        self.cmds.info([])
+        combined = " ".join(self.handler.responses)
+        assert "cmd1" in combined and "cmd2" in combined
+
+    def test_echo_joins_params(self):
+        self.cmds.cmdECHO(["hello", "world"])
+        assert "hello world" in self.handler.responses
+
+    def test_echo_single_word(self):
+        self.cmds.cmdECHO(["hello"])
+        assert "hello" in self.handler.responses
+
+    async def test_timer_no_params_writes_error(self):
+        await self.cmds.timer([])
+        assert self.handler.errors
+
+    async def test_timer_non_integer_writes_error(self):
+        await self.cmds.timer(["notanumber", "hello"])
+        assert self.handler.errors
+
+    async def test_timer_writes_waiting_message(self):
+        await self.cmds.timer(["60", "hello"])
+        assert any("Waiting" in r for r in self.handler.responses)
+        for t in self.handler.timer_events:
+            t.cancel()
+
+    async def test_timer_creates_asyncio_task(self):
+        await self.cmds.timer(["60", "hello"])
+        assert len(self.handler.timer_events) == 1
+        assert isinstance(self.handler.timer_events[0], asyncio.Task)
+        self.handler.timer_events[0].cancel()
+
+    async def test_timer_fires_message_after_delay(self):
+        await self.cmds.timer(["0", "ping"])
+        await asyncio.sleep(0.05)
+        assert "ping" in self.handler.messages
+
+    async def test_set_password_matching_writes_success(self):
+        self.handler._readline_responses = ["secret", "secret"]
+        await self.cmds.set_password([])
+        assert any("Pretending" in r for r in self.handler.responses)
+
+    async def test_set_password_mismatch_writes_error(self):
+        self.handler._readline_responses = ["secret", "wrong"]
+        await self.cmds.set_password([])
+        assert self.handler.errors
+
+    async def test_set_password_from_params_strips_history(self):
+        self.handler.history = ["passwd mysecret"]
+        self.handler._readline_responses = ["mysecret"]
+        await self.cmds.set_password(["mysecret"])
+        assert self.handler.history[-1] == "passwd"
+
+    def test_connections_shows_count(self):
+        self.handler.myserver.connection_count = 7
+        self.cmds.connections([])
+        assert "7" in " ".join(self.handler.responses)
+
+    def test_users_shows_usernames(self):
+        self.handler.myserver.user_connect = {"alice": 3, "bob": 1}
+        self.cmds.users([])
+        combined = " ".join(self.handler.responses)
+        assert "alice" in combined and "bob" in combined
+
+    def test_users_shows_counts(self):
+        self.handler.myserver.user_connect = {"alice": 3}
+        self.cmds.users([])
+        assert "3" in " ".join(self.handler.responses)
+
+    def test_command_do_nothing_writes_response(self):
+        self.cmds.command_do_nothing([])
+        assert any("nothing" in r.lower() for r in self.handler.responses)
+
+
+# ---------------------------------------------------------------------------
+# ExampleTelnetHandler
+# ---------------------------------------------------------------------------
+
+
+class TestExampleTelnetHandler:
+    def test_prompt_is_configured(self):
+        assert ExampleTelnetHandler.PROMPT == "TestServer> "
+
+    def test_welcome_mentions_server(self):
+        assert "server" in ExampleTelnetHandler.WELCOME.lower()
+
+    def test_auth_need_user_is_true(self):
+        assert ExampleTelnetHandler.authNeedUser is True
+
+    def test_auth_need_pass_is_false(self):
+        assert ExampleTelnetHandler.authNeedPass is False
+
+    def test_auth_callback_accepts_nonempty_username(self):
+        h = make_handler()
+        h.authCallback("alice", "")  # must not raise
+
+    def test_auth_callback_rejects_empty_username(self):
+        h = make_handler()
+        with pytest.raises(BaseException):
+            h.authCallback("", "")
+
+    def test_session_start_initializes_timer_events(self):
+        h = make_handler()
+        h.username = "alice"
+        h.session_start()
+        assert h.timer_events == []
+
+    def test_session_start_writes_username(self):
+        h = make_handler()
+        h.username = "alice"
+        h.session_start()
+        assert "alice" in recv(h)
+
+    def test_session_start_writes_asyncio(self):
+        h = make_handler()
+        h.username = "alice"
+        h.session_start()
+        assert "asyncio" in recv(h)
+
+    def test_session_start_writes_connection_count(self):
+        # Reset to a known server state for this test.
+        original_server = ExampleTelnetHandler.myserver
+        ExampleTelnetHandler.myserver = MyServer()
+        try:
+            h = make_handler()
+            h.username = "alice"
+            h.session_start()
+            assert "1" in recv(h)
+        finally:
+            ExampleTelnetHandler.myserver = original_server
+
+    def test_session_end_cancels_pending_tasks(self):
+        h = make_handler()
+        h.username = "alice"
+        h.session_start()
+        mock_task = mock.MagicMock()
+        h.timer_events = [mock_task]
+        h.session_end()
+        mock_task.cancel.assert_called_once()
+
+    def test_session_end_cancels_multiple_tasks(self):
+        h = make_handler()
+        h.username = "alice"
+        h.session_start()
+        tasks = [mock.MagicMock(), mock.MagicMock()]
+        h.timer_events = tasks
+        h.session_end()
+        for t in tasks:
+            t.cancel.assert_called_once()
+
+    def test_writeerror_wraps_in_ansi_red(self):
+        h = make_handler()
+        h.writeerror("bad input")
+        output = recv(h)
+        assert "\x1b[91m" in output
+        assert "bad input" in output
+        assert "\x1b[0m" in output
+
+    def test_commands_class_is_my_commands(self):
+        assert ExampleTelnetHandler.commands_class is MyCommands
+
+
+# ---------------------------------------------------------------------------
+# Integration: real asyncio server using ExampleTelnetHandler
+# ---------------------------------------------------------------------------
+
+
+def _strip_iac(data: bytes) -> bytes:
+    IAC_B = 255
+    WILL_B, WONT_B, DO_B, DONT_B = 251, 252, 253, 254
+    SB_B, SE_B = 250, 240
+    out = bytearray()
+    i = 0
+    while i < len(data):
+        b = data[i]
+        if b == IAC_B and i + 1 < len(data):
+            cmd_b = data[i + 1]
+            if cmd_b in (WILL_B, WONT_B, DO_B, DONT_B) and i + 2 < len(data):
+                i += 3
+                continue
+            elif cmd_b == SB_B:
+                while i < len(data) and data[i] != SE_B:
+                    i += 1
+                i += 1
+                continue
+            else:
+                i += 2
+                continue
+        out.append(b)
+        i += 1
+    return bytes(out)
+
+
+async def _read_until(reader, marker: bytes, timeout: float = 3.0) -> bytes:
+    buf = b""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while marker not in buf:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            break
+        try:
+            chunk = await asyncio.wait_for(
+                reader.read(4096), timeout=min(remaining, 0.3)
+            )
+        except asyncio.TimeoutError:
+            break
+        if not chunk:
+            break
+        buf += _strip_iac(chunk)
+    return buf
+
+
+class _IntegrationHandler(ExampleTelnetHandler):
+    """No telnet negotiation or option-negotiation delay for integration tests."""
+
+    OPTION_NEGOTIATION_DELAY = 0
+    authNeedUser = False
+    authNeedPass = False
+    authCallback = None
+
+    async def setup(self):
+        self.setterm(self.TERM)
+        self.sock = None
+        self._task_ic = asyncio.create_task(self.inputcooker())
+
+    def session_start(self):
+        self.timer_events = []
+        self.writeline("INTEGRATION READY")
+
+
+@pytest.fixture
+async def server_addr():
+    server = await asyncio.start_server(
+        _IntegrationHandler.asyncio_handle, "127.0.0.1", 0
+    )
+    addr = server.sockets[0].getsockname()
+    yield addr
+    server.close()
+    await server.wait_closed()
+
+
+class TestIntegration:
+    async def test_welcome_received(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        data = await _read_until(reader, b"INTEGRATION READY")
+        assert b"INTEGRATION READY" in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_prompt_appears(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        data = await _read_until(reader, b"TestServer> ")
+        assert b"TestServer> " in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_echo_command(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        await _read_until(reader, b"TestServer> ")
+        writer.write(b"echo hello world\n")
+        data = await _read_until(reader, b"TestServer> ")
+        assert b"hello world" in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_params_command(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        await _read_until(reader, b"TestServer> ")
+        writer.write(b"params foo bar\n")
+        data = await _read_until(reader, b"TestServer> ")
+        assert b"foo" in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_info_command(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        await _read_until(reader, b"TestServer> ")
+        writer.write(b"info\n")
+        data = await _read_until(reader, b"TestServer> ")
+        assert b"terminal" in data.lower() or b"Width" in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_timer_fires_message(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        await _read_until(reader, b"TestServer> ")
+        writer.write(b'timer 0 "ping"\n')
+        data = await _read_until(reader, b"ping", timeout=2.0)
+        assert b"ping" in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_unknown_command_writes_error(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        await _read_until(reader, b"TestServer> ")
+        writer.write(b"NOSUCH\n")
+        data = await _read_until(reader, b"TestServer> ")
+        assert b"NOSUCH" in data or b"Unknown" in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_exit_command(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        await _read_until(reader, b"TestServer> ")
+        writer.write(b"exit\n")
+        data = await _read_until(reader, b"Goodbye")
+        assert b"Goodbye" in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_help_lists_commands(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        await _read_until(reader, b"TestServer> ")
+        writer.write(b"help\n")
+        data = await _read_until(reader, b"TestServer> ")
+        assert b"ECHO" in data or b"TIMER" in data or b"INFO" in data
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_abrupt_disconnect_does_not_hang(self, server_addr):
+        reader, writer = await asyncio.open_connection(*server_addr)
+        await _read_until(reader, b"TestServer> ")
+        writer.close()
+        await writer.wait_closed()
+        await asyncio.sleep(0.1)

--- a/example-asyncio.py
+++ b/example-asyncio.py
@@ -1,0 +1,268 @@
+#!/usr/bin/python
+
+import asyncio
+import curses.ascii
+import logging
+import argparse
+
+logging.getLogger("").setLevel(logging.DEBUG)
+
+TELNET_IP_BINDING = ""  # all interfaces
+
+parser = argparse.ArgumentParser(description="Run an asyncio telnet server.")
+parser.add_argument(
+    "port", metavar="PORT", type=int, help="The port on which to listen."
+)
+parser.add_argument(
+    "-s",
+    "--ssh",
+    action="store_const",
+    const=True,
+    default=False,
+    help="Run as SSH server using Paramiko library.",
+)
+console_args = parser.parse_args()
+
+TELNET_PORT_BINDING = console_args.port
+
+from telnetsrv.aio import TelnetHandler, cmd, Commands  # noqa: E402
+
+
+class MyCommands(Commands):
+    """Commands for the asyncio example server."""
+
+    @cmd
+    def debug(self, params):
+        """
+        Display some debugging data
+        """
+        for v, k in self.handler.ESCSEQ.items():
+            line = "%-10s : " % (self.handler.KEYS[k],)
+            for c in v:
+                if ord(c) < 32 or ord(c) > 126:
+                    line = line + curses.ascii.unctrl(c)
+                else:
+                    line = line + c
+            self.handler.writeresponse(line)
+
+    @cmd
+    def params(self, params):
+        """[<params>]*
+        Echos back the raw received parameters.
+        """
+        self.handler.writeresponse("params == %r" % params)
+
+    @cmd
+    def info(self, params):
+        """
+        Provides some information about the current terminal.
+        """
+        self.handler.writeresponse(
+            f"Username: {self.handler.username}, " f"terminal type: {self.handler.TERM}"
+        )
+        self.handler.writeresponse(
+            f"Width: {self.handler.WIDTH}, height: {self.handler.HEIGHT}"
+        )
+        self.handler.writeresponse("Command history:")
+        for c in self.handler.history:
+            self.handler.writeresponse("  %r" % c)
+
+    @cmd(["timer", "timeit"])
+    async def timer(self, params):
+        """<time> <message>
+        In <time> seconds, display <message>.
+        Send a message after a delay.
+        <time> is in seconds.
+        If <message> is more than one word, quotes are required.
+
+        example: TIMER 5 "hello world!"
+        """
+        try:
+            timestr, message = params[:2]
+            delay = int(timestr)
+        except ValueError:
+            self.handler.writeerror("Need both a time and a message")
+            return
+        self.handler.writeresponse("Waiting %d seconds..." % delay)
+
+        async def _fire():
+            await asyncio.sleep(delay)
+            self.handler.writemessage(message)
+
+        task = asyncio.create_task(_fire())
+        self.handler.timer_events.append(task)
+
+    @cmd("passwd")
+    async def set_password(self, params):
+        """[<password>]
+        Pretends to set a console password.
+        Demonstrates how sensitive information may be handled.
+        """
+        try:
+            password = params[0]
+        except IndexError:
+            password = await self.handler.readline(
+                prompt="New Password: ", echo=False, use_history=False
+            )
+        else:
+            # Strip the password from history to prevent easy snooping.
+            self.handler.history[-1] = "passwd"
+
+        password2 = await self.handler.readline(
+            prompt="Retype New Password: ", echo=False, use_history=False
+        )
+        if password == password2:
+            self.handler.writeresponse(
+                "Pretending to set new password, but not really."
+            )
+        else:
+            self.handler.writeerror("Passwords don't match.")
+
+    def cmdECHO(self, params):
+        """<text to echo>
+        Echo text back to the console.
+
+        """
+        self.handler.writeresponse(" ".join(params))
+
+    cmdECHO.aliases = ["REPEAT"]
+
+    def cmdTERM(self, params):
+        """
+        Hidden command to print the current TERM
+        """
+        self.handler.writeresponse(self.handler.TERM)
+
+    cmdTERM.hidden = True
+
+    @cmd("hide-me", hidden=True)
+    @cmd(["hide-me-too", "also-me"])
+    def command_do_nothing(self, params):
+        """
+        Hidden command to perform no action
+        """
+        self.handler.writeresponse("Nope, did nothing.")
+
+    @cmd
+    def connections(self, params: list[str]) -> None:
+        """
+        Show how many logins there have been.
+        """
+        self.handler.writeresponse(
+            f"There have been {self.handler.myserver.connection_count} connections"
+        )
+
+    @cmd(["who", "users"])
+    def users(self, params: list[str]) -> None:
+        """
+        Show who has logged in.
+        """
+        for user, count in self.handler.myserver.user_connect.items():
+            self.handler.writeresponse(f"{user} : {count}")
+
+
+class MyServer:
+    """A simple server class that keeps track of connection counts."""
+
+    def __init__(self):
+        self.connection_count = 0
+        self.user_connect = {}
+
+    def new_connection(self, username):
+        """Register a new connection by username, return the count of connections."""
+        self.connection_count += 1
+        try:
+            self.user_connect[username] += 1
+        except KeyError:
+            self.user_connect[username] = 1
+        return self.connection_count, self.user_connect[username]
+
+
+class ExampleTelnetHandler(TelnetHandler):
+    commands_class = MyCommands
+    myserver = MyServer()
+
+    WELCOME = "You have connected to the asyncio test server."
+    PROMPT = "TestServer> "
+    authNeedUser = True
+    authNeedPass = False
+
+    def authCallback(self, username, password):
+        """Called to validate the username/password."""
+        if not username:
+            raise ValueError("Username required")
+
+    def session_start(self):
+        """Called after the user successfully logs in."""
+        self.writeline("This server is running asyncio.")
+        globalcount, usercount = self.myserver.new_connection(self.username)
+        self.writeline("Hello %s!" % self.username)
+        self.writeline(
+            "You are connection #%d, you have logged in %s time(s)."
+            % (globalcount, usercount)
+        )
+        self.timer_events = []
+
+    def session_end(self):
+        """Called after the user logs off."""
+        for task in self.timer_events:
+            task.cancel()
+
+    def writeerror(self, text):
+        """Write errors in ANSI red."""
+        TelnetHandler.writeerror(self, "\x1b[91m%s\x1b[0m" % text)
+
+
+if __name__ == "__main__":
+    if console_args.ssh:
+        # SSH transport is blocking and thread-based (Paramiko).  Each connection
+        # gets its own thread; asyncio.run() is called inside that thread to drive
+        # the async TelnetHandler for that session.
+        import socketserver
+        from telnetsrv.aio_ssh import AsyncSSHHandler, getRsaKeyFile
+
+        # Wire ExampleTelnetHandler as the PTY session handler and load (or
+        # generate) the RSA host key that identifies this server to clients.
+        class TestSSHHandler(AsyncSSHHandler):
+            telnet_handler = ExampleTelnetHandler
+            host_key = getRsaKeyFile("server_rsa.key")
+
+        # allow_reuse_address avoids "address already in use" on quick restarts.
+        class TelnetServer(socketserver.TCPServer):
+            allow_reuse_address = True
+
+        # Bind and hand each accepted connection to TestSSHHandler.
+        server = TelnetServer(
+            (TELNET_IP_BINDING or "0.0.0.0", TELNET_PORT_BINDING), TestSSHHandler
+        )
+        logging.info(
+            "Starting asyncio SSH server at port %d.  (Ctrl-C to stop)"
+            % TELNET_PORT_BINDING
+        )
+        try:
+            # Block here, dispatching connections until Ctrl-C.
+            server.serve_forever()
+        except KeyboardInterrupt:
+            logging.info("Server shut down.")
+    else:
+        # Plain telnet: the handler runs entirely inside a single asyncio event loop.
+        async def main():
+            # Start the TCP listener; asyncio_handle is called for each new connection.
+            server = await asyncio.start_server(
+                ExampleTelnetHandler.asyncio_handle,
+                host=TELNET_IP_BINDING or "0.0.0.0",
+                port=TELNET_PORT_BINDING,
+            )
+            logging.info(
+                "Starting asyncio telnet server at port %d.  (Ctrl-C to stop)"
+                % TELNET_PORT_BINDING
+            )
+            # async with keeps server open; serve_forever() suspends until cancelled.
+            async with server:
+                await server.serve_forever()
+
+        try:
+            # Run the event loop until main() exits or KeyboardInterrupt is raised.
+            asyncio.run(main())
+        except KeyboardInterrupt:
+            logging.info("Server shut down.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ line-length = 88
 target-version = ["py310", "py311", "py312", "py313"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "example-test.py"]
+testpaths = ["tests", "example-test.py", "example-asyncio-test.py"]
 python_files = ["test_*.py", "*_test.py", "*-test.py"]
 addopts = "--tb=short -q"
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "telnetsrv"
-version = "1.0.1"
+version = "1.0.2"
 description = "Telnet server handler library"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -808,7 +808,7 @@ wheels = [
 
 [[package]]
 name = "telnetsrv"
-version = "1.0"
+version = "1.0.1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -808,7 +808,7 @@ wheels = [
 
 [[package]]
 name = "telnetsrv"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- **`example-asyncio.py`**: full-featured demo using `telnetsrv.aio`; `timer` uses `asyncio.create_task` for non-blocking delayed messages, `passwd` uses `await handler.readline()`, SSH mode served via `socketserver.TCPServer` + `AsyncSSHHandler` (each session runs its own `asyncio.run()` internally)
- **`example-asyncio-test.py`**: 52 tests covering `MyServer`, `MyCommands` (including async `timer`/`passwd`), `ExampleTelnetHandler`, and live integration tests against a real `asyncio.start_server`; added to `pytest testpaths`
- **`README.md`**: fixed two-flavor references to three (threaded/green/asyncio), updated intro and "Serving the Handler" paragraph, updated "Short Example" to use asyncio, added descriptions to "Longer Example" and new "Asyncio Example" sections
- **`pyproject.toml`**: version bumped to 1.0.2

## Test plan

- [x] `uv run pytest` — all 465 tests pass (includes the 52 new asyncio example tests)
- [x] `uv run black --check example-asyncio.py example-asyncio-test.py` — clean
- [x] `uv run flake8 example-asyncio.py example-asyncio-test.py` — clean
- [x] Run `python example-asyncio.py 8023` and connect with a telnet client to verify interactive behavior
- [ ] Run `python example-asyncio.py 8022 --ssh` and connect with an SSH client to verify SSH path

🤖 Generated with [Claude Code](https://claude.com/claude-code)